### PR TITLE
Solved outstanding issues mentioned in snscrape#413

### DIFF
--- a/snscrape/base.py
+++ b/snscrape/base.py
@@ -193,7 +193,6 @@ class Scraper:
 			# The request is newly prepared on each retry because of potential cookie updates.
 			req = self._session.prepare_request(requests.Request(method, url, params = params, data = data, headers = headers))
 			environmentSettings = self._session.merge_environment_settings(req.url, proxies, None, None, None)
-			_logger.info("Hey there, I'm in here")
 			_logger.info(f'Retrieving {req.url}')
 			_logger.debug(f'... with headers: {headers!r}')
 			if data:

--- a/snscrape/base.py
+++ b/snscrape/base.py
@@ -193,6 +193,7 @@ class Scraper:
 			# The request is newly prepared on each retry because of potential cookie updates.
 			req = self._session.prepare_request(requests.Request(method, url, params = params, data = data, headers = headers))
 			environmentSettings = self._session.merge_environment_settings(req.url, proxies, None, None, None)
+			_logger.info("Hey there, I'm in here")
 			_logger.info(f'Retrieving {req.url}')
 			_logger.debug(f'... with headers: {headers!r}')
 			if data:

--- a/snscrape/modules/telegram.py
+++ b/snscrape/modules/telegram.py
@@ -336,7 +336,9 @@ def _parse_video_message(videoPlayer):
 		mKwargs['duration'] = _durationStrToSeconds(durationStr)
 	return cls(**mKwargs)
 
+
 class TestTelegramChannelScraper(unittest.TestCase):
+	"""Run suite by directly calling this file."""
 
 	@staticmethod
 	def execute_with_timeout(func, timeout=10):

--- a/snscrape/modules/telegram.py
+++ b/snscrape/modules/telegram.py
@@ -338,7 +338,7 @@ def _parse_video_message(videoPlayer):
 
 
 class TestTelegramChannelScraper(unittest.TestCase):
-	"""Run suite by directly calling this file."""
+	"""Run suite by directly running this file."""
 
 	@staticmethod
 	def execute_with_timeout(func, timeout=10):
@@ -383,7 +383,7 @@ class TestTelegramChannelScraper(unittest.TestCase):
 		self.execute_with_timeout(scrape_two_pages)
 
 	def test_scraping_termination_small_post_count(self):
-		"""Test scraping always terminates, even with small number of posts. This channel has only 28."""
+		"""Test scraping always terminates, even with small number of posts. This channel's highest ID is 28."""
 
 		def scrape_small_channel():
 			scraper = TelegramChannelScraper('AKCPB')
@@ -392,8 +392,8 @@ class TestTelegramChannelScraper(unittest.TestCase):
 		
 		self.execute_with_timeout(scrape_small_channel)
 
-	def test_scraping_termination_channels_without_post_id_one(self):
-		"""Test scraping gracefully handles channels missing a post where id=1."""
+	def test_scraping_termination_pages_without_posts(self):
+		"""Test scraping gracefully handles pages without any posts."""
 
 		def scrape_empty_page():
 			scraper = TelegramChannelScraper('BREAKDCODE?before=3')
@@ -407,10 +407,11 @@ class TestTelegramChannelScraper(unittest.TestCase):
 		scraper = TelegramChannelScraper('nexta_live?before=43103')
 		item = next(scraper.get_items(), None)
 		self.assertIsNotNone(item, "Failed to scrape any posts.")
+
+		# This particular post is known to include media [Video, Photo, Video]
 		self.assertEqual(item.url, "https://t.me/s/nexta_live/43102")
 
-		# Directly validate the types of the objects in the media array
-		expected_types = [Video, Photo, Video]  # Adjust based on expected types
+		expected_types = [Video, Photo, Video]
 		actual_types = [type(media) for media in item.media] if item.media else []
 		
 		self.assertEqual(actual_types, expected_types, "Media did not appear in the expected order.")

--- a/snscrape/modules/telegram.py
+++ b/snscrape/modules/telegram.py
@@ -212,7 +212,6 @@ class TelegramChannelScraper(snscrape.base.Scraper):
 			return
 		nextPageUrl = ''
 		while True:
-			print("About to yield from get_items")
 			yield from self._soup_to_items(soup, r.url)
 			dateElt = soup.find('a', attrs = {'class': 'tgme_widget_message_date'}, href = True)
 			if dateElt and 'href' in dateElt.attrs:

--- a/snscrape/modules/telegram.py
+++ b/snscrape/modules/telegram.py
@@ -196,7 +196,7 @@ class TelegramChannelScraper(snscrape.base.Scraper):
 				}
 				timeTag = videoPlayer.find('time')
 				if timeTag is None:
-					_logger.warning(f'Could not find duration for video or GIF at {url}')
+					# Example of duration-less GIF: https://t.me/thisisatestchannel19451923/3
 					cls = Gif
 				else:
 					cls = Video


### PR DESCRIPTION
Setting up this pull request to track my work in progress here!  Here are the 5 issues [called out](https://github.com/JustAnotherArchivist/snscrape/pull/413#pullrequestreview-1223678731) by @JustAnotherArchivist, along with my progress on each:

- [x]  Validating multiple matches on image regex
- [x] Maintaining order of media by merging loop into main link loop.  Validated behavior by retrieving https://t.me/s/nexta_live/43102, which now had the videos and images in the correct order.
- [X] Confirming that some GIFs present as duration-less videos -- thanks for providing the link, Logan!  I added a log statement, but will remove it in my next commit now that you've validated.
- [X] Leaving the link preview href within the `outlinks` array for consistency with other scrapers
- [X] Update the scraper break from using a try/except to instead using an if statement that won't throw an Exception.
- [x] Strengthening logic for getting next page => Using the `prev` link in the header, which accounts for media getting separate IDs.
